### PR TITLE
new create(ServletContext) method

### DIFF
--- a/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/DbUnitOperator.groovy
+++ b/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/DbUnitOperator.groovy
@@ -45,15 +45,28 @@ class DbUnitOperator {
 	 */
     static create() {
 
-    	def op = new DbUnitOperatorImpl()    	op.create()
+    	def op = new DbUnitOperatorImpl()
+    	op.create()
     }
-	/**
+    
+     static create(ServletContext servletContext) { 
+		
+    	def op = new DbUnitOperatorImpl(new Configuration(), servletContext)
+    	op.create()
+    }	
+
+	/**
 	 * Operate data based on configuration (initial data, DBUnit dataset file format)
 	 * within 'DataSource.groovy' and given DBUnit-operation 'operationType' specified.
 	 *
 	 * @param operationType DBUnit-opration type (String, e.g. "CLEAN_INSERT").
 	 */
-    static operate(operationType) {    	def op = new DbUnitOperatorImpl()    	op.operate (operationType)    }	/**
+    static operate(operationType) {
+    	def op = new DbUnitOperatorImpl()
+    	op.operate (operationType)
+    }
+
+	/**
 	 * Operate data based on configuration (DBUnit dataset file format) within
 	 * 'DataSource.groovy' and given dataset file 'filePath' and DBUnit-operation
 	 * 'operationType' specified.
@@ -64,5 +77,7 @@ class DbUnitOperator {
 	 */
     static operate(operationType, filePath) {
 
-		def op = new DbUnitOperatorImpl()    	op.operate (operationType, filePath)    }
+		def op = new DbUnitOperatorImpl()
+    	op.operate (operationType, filePath)
+    }
 }


### PR DESCRIPTION
If you call `DbUnitOperatorImpl.create()` (test env), the code uses `ServletContextHolder.getServletContext()`. In Grails 2.x you get a mock implementacion of ServletContext. 

With this new method you can inject the real ServletContext in `BootStrap.groovy` this way:

```
DbUnitOperator.create(servletContext);
```

So `DbUnitOperatorImpl` will work with real servletContext in integration test and you will get real path for dbunit xml files.
