### PR TITLE
Add FEATURE_QUALIFIED_TABLE_NAMES capability

### DIFF
--- a/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/Configuration.groovy
+++ b/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/Configuration.groovy
@@ -45,6 +45,7 @@ class Configuration {
     private static final String KEY_INITIAL_OPERATION = "initialOperation"
     private static final String KEY_XML_TYPE = "dbunitXmlType"
     private static final String KEY_ORDER_TABLES = "orderTables"
+	private static final String KEY_QUALIFIED_TABLE_NAMES = "qualified_table_names"
 
     private ConfigObject config
 
@@ -52,6 +53,7 @@ class Configuration {
     private String operationType
     private String dbunitXmlType
     private boolean orderTables = false
+	private boolean qualifiedTableNames = false
 
     private String url
     private String username
@@ -86,6 +88,12 @@ class Configuration {
         if (o != null) {
             this.orderTables = Boolean.getBoolean(config.getProperty(KEY_ORDER_TABLES).toString())
         }
+		
+		this.qualifiedTableNames = false
+		Object oqtn = config.getProperty(KEY_QUALIFIED_TABLE_NAMES)
+		if (oqtn != null) {
+			this.qualifiedTableNames = Boolean.getBoolean(config.getProperty(KEY_QUALIFIED_TABLE_NAMES).toString())
+		}
 
         log.debug "ORDER TABLES = " + this.orderTables
 
@@ -205,4 +213,12 @@ class Configuration {
     String getJndiName() {
         return this.jndiName
     }
+	
+	/**
+	 * Return Qualified Table Name name.
+	 * @return Qualified Table Name name
+	 */
+	String getQualifiedTableNames() {
+		return this.qualifiedTableNames
+	}
 }

--- a/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/DbUnitOperatorImpl.groovy
+++ b/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/DbUnitOperatorImpl.groovy
@@ -209,7 +209,7 @@ class DbUnitOperatorImpl {
 
             conn = new DatabaseConnection(sql.getConnection())
 
-            // workaround since dbunit complains
+			// workaround since dbunit complains
             if (!config.isJndiBased()) {
                String s = config.getDriver()
 	            if (s.startsWith("com.mysql")) {
@@ -225,6 +225,12 @@ class DbUnitOperatorImpl {
 	            } else {
 	                conn.getConfig().setProperty(DatabaseConfig.PROPERTY_DATATYPE_FACTORY,new DefaultDataTypeFactory())
 	            }
+				
+				if(config.getQualifiedTableNames())
+				{
+					conn.getConfig().setProperty(DatabaseConfig.FEATURE_QUALIFIED_TABLE_NAMES,true)
+				}
+				
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
When creating a connection to an Oracle database, DBUnit will populate a
Map of table names. By default these will not be prefixed with the
schema name. As a result, you can get duplicate table names or you
cannot use schemas using this plugin.

I am using an Oracle Database with diferent Schemas.

Reference: http://city81.blogspot.com/2011/06/junit-dbunit-and-oracle.html
