### PR TITLE
Not getting properly the Boolean value of the qualifiedTableNames property

### DIFF
--- a/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/Configuration.groovy
+++ b/dbunit-operator/src/groovy/ch/gstream/grails/plugins/dbunitoperator/Configuration.groovy
@@ -93,7 +93,7 @@ class Configuration {
 		this.qualifiedTableNames = false
 		Object oqtn = config.getProperty(KEY_QUALIFIED_TABLE_NAMES)
 		if (oqtn != null) {
-			this.qualifiedTableNames = Boolean.getBoolean(config.getProperty(KEY_QUALIFIED_TABLE_NAMES).toString())
+			this.qualifiedTableNames = config.getProperty(KEY_QUALIFIED_TABLE_NAMES)
 		}
 
         log.debug "ORDER TABLES = " + this.orderTables


### PR DESCRIPTION
I started working again with this wonderful plugin and I realized that the qualifiedTableNames property value was not setting properly because it is a boolean value.

I did not have time to check the orderTables property but it could happen the same.

When I was getting the property value and the invoking the method toString it was returnin the whole datasource configuration. Now with this fix it is returning just the boolean value.

Thanks
Juan
